### PR TITLE
mvto: available_space_afs add missing space after -server

### DIFF
--- a/mvto
+++ b/mvto
@@ -146,7 +146,7 @@ sub available_space_afs {
         return;
     }
     open(INFO,
-        "$VOS partinfo -server$server -partition $partition $LOCALAUTH |")
+        "$VOS partinfo -server $server -partition $partition $LOCALAUTH |")
       or die "$0: can't fork: $!\n";
     local $_;
     while (<INFO>) {


### PR DESCRIPTION
e50265e9ec616c5f6b9fae79e8ff290b7a727aa0 ("Add support for Auristor, reformat Perl") left out the space resulting in a command line parsing error.