### PR TITLE
Cleanup of install and test from master source

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,21 @@
                    User-Visible afs-admin-tools Changes
 
+afs-admin-tools 2.6 (2024-07-25)
+
+    * volcreate POD updates
+    * Updates to afs-mkmove-r* scripts
+      - Address warnings caused by using bare words to identify
+        IO handles.
+      - Updates to file header describe the script.
+      - Update copyright and license information.
+      - Add "use warnings"
+    * Restrict strict tests to perl scripts directory
+    * Code cleanup
+    * perltidy updates to scripts
+    * Make sure the Auristor detection executes only after the
+      help display.  This allows help to be run on systems without
+      AFS installed.
+
 afs-admin-tools 2.5 (2024-07-17)
 
     Bug fix release.

--- a/afs-mkmove-ro
+++ b/afs-mkmove-ro
@@ -1,8 +1,22 @@
 #!/usr/bin/perl
+our $VERSION = '2.6 (2024-07-25)';
+#
+# File: afs-mkmove-ro - Use mvto to move AFS volumes
+#
+# Description: This script can be used to all the volumes from one
+# server to another.  This script processes readonly volumes only.
+#
+# Author: Bill MacAllister <bill@ca-zephyr.org
+#
+# Copyright 2008-2015
+#    The Board of Trustees of the Leland Stanford Junior University
+# Copyright 2018, 2024
+#    Bill MacAllister <bill@ca-zephyr.org>
 
 use Getopt::Long;
 use Pod::Usage;
 use strict;
+use warnings;
 
 use vars qw(
             @inParts
@@ -30,11 +44,11 @@ sub get_datetime {
     if (length($now)==0) {$now = time;}
     my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) = localtime($now);
     $mon++;
-    $mon = sprintf ("%02d",$mon);
-    $mday = sprintf ("%02d",$mday);
-    $hour = sprintf ("%02d",$hour);
-    $min = sprintf ("%02d",$min);
-    $sec = sprintf ("%02d",$sec);
+    $mon  = sprintf("%02d", $mon);
+    $mday = sprintf("%02d", $mday);
+    $hour = sprintf("%02d", $hour);
+    $min  = sprintf("%02d", $min);
+    $sec  = sprintf("%02d", $sec);
     $year += 1900;
     return $year.'-'.$mon.'-'.$mday.'-'.$hour.'-'.$min.'-'.$sec;
 }
@@ -61,7 +75,7 @@ sub get_filename {
 
 sub sql_list {
 
-    my $sql = "SELECT server, part, volname, used FROM volumes " 
+    my $sql = "SELECT server, part, volname, used FROM volumes "
         . "WHERE server = '$opt_inserver' "
         . "AND type = 'RO' ";
     if ($opt_inparts) {
@@ -70,7 +84,7 @@ sub sql_list {
         foreach my $p (@inParts) {
             my $qpart = $p;
             $qpart = "/vicep$p" if length($p) == 1;
-            $sql .= "${word}part = '$qpart'"; 
+            $sql .= "${word}part = '$qpart'";
             $word = ' OR ';
         }
         $sql .= ')';
@@ -89,23 +103,23 @@ sub sql_list {
 }
 
 # ---------------------------
-# Read and parse vos listvol output 
+# Read and parse vos listvol output
 
 sub vos_list {
 
     my ($thisFile) = @_;
 
     if (! -e $thisFile) {
-        print "SU-F-FNF, volume list file not found ($thisFile)\n";
+        print("ERROR: volume list file not found ($thisFile)\n");
         exit 1;
     }
 
     my $thisPart = '';
-    open infile, "<$thisFile";
-    while (<infile>) {
+    open(my $infile, '<', $thisFile);
+    while (<$infile>) {
         chomp;
         my $inline = $_;
-        
+
         if ($inline =~ /partition\s+\/vicep(\w+):\s+/) {
             $thisPart = $1;
             next;
@@ -119,14 +133,14 @@ sub vos_list {
         }
     }
 
-    close infile;
+    close $infile;
 }
 
 # ---------------------------
 # Pick a partition
 
 sub pick_partition  {
-    
+
     my ($in_part, $this_size) = @_;
 
     my $return_part = '';
@@ -178,12 +192,12 @@ if ($opt_manual) {
 }
 
 if (length($opt_inserver) == 0) {
-    print "SU-F-SRVREQ, --inserver is required\n";
+    print("ERROR:  --inserver is required\n");
     pod2usage(-verbose => 0);
 }
 
 if (length($opt_outserver) == 0) {
-    print "SU-F-SRVREQ, --outserver is required\n";
+    print("ERROR: --outserver is required\n");
     pod2usage(-verbose => 0);
 }
 
@@ -221,14 +235,14 @@ if ($opt_sqllist) {
         foreach my $p (@inParts) {
             my $list = "vollist-${opt_inserver}-${p}-".get_datetime().".txt";
             my $cmd = "vos listvol $opt_inserver $p > $list";
-            print "Getting a volume list of $opt_inserver $p ...\n";
+            print("Getting a volume list of $opt_inserver $p ...\n");
             system ($cmd);
             vos_list($list);
-        } 
+        }
     } else {
         my $list = "vollist-${opt_inserver}-".get_datetime().".txt";
         my $cmd = "vos listvol $opt_inserver > $list";
-        print "Getting a volume list of $opt_inserver ...\n";
+        print("Getting a volume list of $opt_inserver ...\n");
         system ($cmd);
         vos_list($list);
         unlink $list;
@@ -247,22 +261,22 @@ foreach my $p (@infoLines) {
         if ($thisFree < 1) {next;}
         $serverInfo{$opt_outserver}{$thisPart}{'free'} = $thisFree;
         $serverInfo{$opt_outserver}{$thisPart}{'tot'}  = $thisTot;
-        $serverInfo{$opt_outserver}{$thisPart}{'freelimit'} = 
+        $serverInfo{$opt_outserver}{$thisPart}{'freelimit'} =
             $opt_freelimit * $thisTot;
         $partCnt++;
     }
 }
 
 if ($partCnt == 0) {
-    print "SU-F-NOPARTS, no partition information found.\n";
+    print("ERROR: no partition information found.\n");
     exit 1;
 }
 
 my $outFile = get_filename ($opt_inserver, $opt_outserver);
-open out, ">$outFile";
-print "$outFile opened\n";
-print out "#!/bin/bash\n";
-print out "\n";
+open(my $out, '>', $outFile);
+print("$outFile opened\n");
+print($out "#!/bin/bash\n");
+print($out "\n");
 
 my $cnt = 0;
 foreach my $p (sort keys %inPartInfo) {
@@ -275,32 +289,32 @@ foreach my $p (sort keys %inPartInfo) {
             next;
         }
 
-        print out "echo \" \"\n";
-        print out "echo \"-----------------------------------------\"\n";
-        print out "if [ -e ./stopromove ] \n";
-        print out "    then\n";
-        print out "    echo \"stopromove found.  Exiting.\"\n";
-        print out "    exit\n";
-        print out "else\n";
-        print out "    echo \"stopromove not found---continuing.\"\n";
-        print out "fi\n";
-        printf (out "echo \"Move %d - size %d\"\n", 
+        print($out "echo \" \"\n");
+        print($out "echo \"-----------------------------------------\"\n");
+        print($out "if [ -e ./stopromove ] \n");
+        print($out "    then\n");
+        print($out "    echo \"stopromove found.  Exiting.\"\n");
+        print($out "    exit\n");
+        print($out "else\n");
+        print($out "    echo \"stopromove not found---continuing.\"\n");
+        print($out "fi\n");
+        printf($out "echo \"Move %d - size %d\"\n",
                 $cnt, $inPartInfo{$p}{$v});
-        printf (out "echo \"Moving %s from %s %s to %s %s\"\n",
+        printf($out "echo \"Moving %s from %s %s to %s %s\"\n",
                 $v, $opt_inserver, $p, $opt_outserver, $out_part);
-        print out "date\n";
-        print out "/ncsd/batch/mvto -s $v " 
+        print($out "date\n");
+        print($out "/ncsd/batch/mvto -s $v "
             . "$opt_inserver $p "
-            . "$opt_outserver $out_part \n";
+            . "$opt_outserver $out_part \n");
         $cnt++;
     }
 }
-print out "# \n";
-print out "# $cnt moves in all\n";
+print($out "# \n");
+print($out "# $cnt moves in all\n");
 
-close out;
+close $out;
 
-print "$cnt moves in all.\n";
+print("$cnt moves in all.\n");
 
 if ($opt_update) {
     chmod 0755, $outFile;
@@ -311,16 +325,23 @@ exit;
 
 __END__
 
+##############################################################################
+# Documentation
+##############################################################################
+
+=for stopwords
+LSDB afs listvol mkmove mvto pm ro sqllist vos
+
 =head1 NAME
 
-afs-mkmove-ro.pl
+afs-mkmove-ro
 
 =head1 SYNOPSIS
 
- afs-mkmove-ro.pl --inserver=host [--inparts=partition-list] \
-                  --outserver=host [--outparts=partition-list] \
-                  [--vollist=filename] [--sqllist] \
-                  [--update] [--debug] [--help] [--manual] 
+ afs-mkmove-ro --inserver=host [--inparts=partition-list] \
+                --outserver=host [--outparts=partition-list] \
+                [--vollist=filename] [--sqllist] \
+                [--update] [--debug] [--help] [--manual]
 
 =head1 DESCRIPTION
 
@@ -352,8 +373,8 @@ Name of the destination AFS server.
 A comma separate list of partitions.  Optional.  If not specified then
 the source partition is used.  Note, specifying a target partition
 with out specifying a source partition will move all of the read only
-partitions from the source server to a single partiton on the
-destination server.  
+partitions from the source server to a single partition on the
+destination server.
 
 =item --voslist=filename
 
@@ -376,10 +397,21 @@ Print complete documentation.
 
 =back
 
+=head1 COPYRIGHT
+
+Copyright 2008-2015 The Board of Trustees of the Leland Stanford
+Junior University.
+
+Copyright 2018, 2024 Bill MacAllister <bill@ca-zephyr.org>.
+
+=head1 LICENSE
+
+This program is free software; you may redistribute it and/or modify it
+under the same terms as Perl itself.
+
 =head1 AUTHOR
 
 Bill MacAllister <whm@stanford.edu>
 
 =cut
 
- 

--- a/afs-mkmove-rw
+++ b/afs-mkmove-rw
@@ -1,16 +1,25 @@
 #!/usr/bin/perl
-our $VERSION = '2.5 (2024-07-17)';
+our $VERSION = '2.6 (2024-07-25)';
 #
-# afs-mkmove-rw - Use mvto to move AFS volumes
+# File: afs-mkmove-rw - Use mvto to move AFS volumes
 #
-# This script can be used to all the volumes from one server to
-# another.  This script process read/write volumes only.  It moves
-# volumes balanace space among partitions on a server.  The volumes
-# are moved in order from largest to smallest.
+# Description: This script can be used to all the volumes from one
+# server to another.  This script processes read/write volumes only.
+# It moves volumes and balances space among partitions on the target
+# server.  The volumes are moved in order from largest to smallest.
+#
+# Author: Bill MacAllister <bill@ca-zephyr.org
+#
+# Copyright 2008-2015
+#    The Board of Trustees of the Leland Stanford Junior University
+# Copyright 2018, 2024
+#    Bill MacAllister <bill@ca-zephyr.org>
+#
 
 use Getopt::Long;
 use Pod::Usage;
 use strict;
+use warnings;
 
 use vars qw(
             $opt_debug
@@ -34,11 +43,11 @@ sub get_datetime {
     if (length($now)==0) {$now = time;}
     my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) = localtime($now);
     $mon++;
-    $mon = sprintf ("%02d",$mon);
-    $mday = sprintf ("%02d",$mday);
-    $hour = sprintf ("%02d",$hour);
-    $min = sprintf ("%02d",$min);
-    $sec = sprintf ("%02d",$sec);
+    $mon  = sprintf("%02d", $mon);
+    $mday = sprintf("%02d", $mday);
+    $hour = sprintf("%02d", $hour);
+    $min  = sprintf("%02d", $min);
+    $sec  = sprintf("%02d", $sec);
     $year += 1900;
     return $year.'-'.$mon.'-'.$mday.'-'.$hour.'-'.$min.'-'.$sec;
 }
@@ -86,17 +95,17 @@ if ($opt_manual) {
 }
 
 if (length($opt_inserver) == 0 && length($opt_list) == 0) {
-    print "AFS-F-INSRVREQ, either --inserver or --list is required\n";
+    print("ERROR: either --inserver or --list is required\n");
     pod2usage(-verbose => 0);
 }
 
 if (length($opt_outserver) == 0) {
-    print "AFS-F-SRVREQ, --outserver is required\n";
+    print("ERROR: --outserver is required\n");
     pod2usage(-verbose => 0);
 }
 
 if (length($opt_outpart) == 0) {
-    print "AFS-F-SRVREQ, --outpart is required\n";
+    print("ERROR: --outpart is required\n");
     pod2usage(-verbose => 0);
 }
 
@@ -117,13 +126,13 @@ if ($opt_inserver) {
     $delete_list = $opt_list;
     if (length($opt_inpart) == 0) {
         my $cmd = "vos listvol $opt_inserver > $opt_list";
-        print "Getting a volume list ...\n";
+        print("Getting a volume list ...\n");
         system ($cmd);
     } else {
         my @inparts = split ',', $opt_inpart;
         foreach my $p (@inparts) {
             my $cmd = "vos listvol $opt_inserver $p >> $opt_list";
-            print "Getting a volume list for $opt_inserver $p ...\n";
+            print("Getting a volume list for $opt_inserver $p ...\n");
             system ($cmd);
         }
     }
@@ -138,9 +147,9 @@ my $cmd = "vos partinfo $opt_outserver";
 my @r = `$cmd`;
 for my $z (@r) {
     if ($z =~ /vicep(\w):\s+(\d+)[\sA-Za-z]+(\d+)/) {
-        my $part = $1;
-        my $free = $2;
-        my $totl = $3;
+        my $part  = $1;
+        my $free  = $2;
+        my $totl  = $3;
         my $limit = $opt_full * $totl;
         # The amount of space we have left on the partition is
         # the limit - the used.  The used = the total - the free.
@@ -149,9 +158,9 @@ for my $z (@r) {
     }
 }
 
-open infile, "<$opt_list";
+open(my $infile, '<', $opt_list);
 my %parts = ();    
-while (<infile>) {
+while (<$infile>) {
     chomp;
     my $inline = $_;
     if ($inline =~ /([\w\d\.\-]+)\s+\d+\s+RW\s+(\d+)\s+\w+\s+On\-line/) {
@@ -162,7 +171,7 @@ while (<infile>) {
     }
 }
 
-close infile;
+close $infile;
 
 my $outOpened = 0;
 my @outFileList = ();
@@ -173,13 +182,13 @@ my $cnt = 0;
 
 my $outFile = get_filename($opt_outserver, $this_part);
 push @outFileList, $outFile;
-open out, ">$outFile";
-print "$outFile opened\n";
-print out "#!/bin/bash\n";
-print out "\n";
-print out "# ===============================================\n";
-print out "# space available: $out_part_limit{$this_part} for "
-    . " partition $this_part\n";
+open(my $out, '>', $outFile);
+print("$outFile opened\n");
+print($out "#!/bin/bash\n");
+print($out "\n");
+print($out "# ===============================================\n");
+print($out "# space available: $out_part_limit{$this_part} for "
+    . " partition $this_part\n");
 $outOpened = 1;
 
 # Pattern for pulling server info from "vol volinfo" output
@@ -192,19 +201,19 @@ foreach my $sk (keys %parts) {
         my $this_size = $parts{$sk}{$v};
         while ($out_part_size{$this_part}+$this_size 
                > $out_part_limit{$this_part}) {
-            print out "# \n";
+            print($out "# \n");
             $part_index++;
             if ($part_index >= scalar(@part_list)) {
-                print out "# ==============================================\n";
-                print out "# No available space left.  Exiting.\n";
-                print "# ==============================================\n";
-                print "# No available space left.  Exiting.\n";
+                print($out "# ==============================================\n");
+                print($out "# No available space left.  Exiting.\n");
+                print("# ==============================================\n");
+                print("# No available space left.  Exiting.\n");
                 exit;
             }
             $this_part = $part_list[$part_index];
-            print out "# ===============================================\n";
-            print out "# space available: $out_part_limit{$this_part} for "
-                . " partition $this_part\n";
+            print($out "# ===============================================\n");
+            print($out "# space available: $out_part_limit{$this_part} for "
+                . " partition $this_part\n");
         }
 
         my @thisInfo = `vos volinfo $v`;
@@ -223,31 +232,31 @@ foreach my $sk (keys %parts) {
 
         $cnt++;
         $out_part_size{$this_part} += $this_size;
-        print out "echo \" \"\n";
-        print out "echo \"=========================================\"\n";
-        print out "if [ -e ./stopmove ] \n";
-        print out "    then\n";
-        print out "    echo \"stopmove found.  Exiting.\"\n";
-        print out "    exit\n";
-        print out "else\n";
-        print out "    echo \"stopmove not found---continuing.\"\n";
-        print out "fi\n";
-        printf (out "echo \"Moving %s - move %d - size %d\"\n", 
+        print($out "echo \" \"\n");
+        print($out "echo \"=========================================\"\n");
+        print($out "if [ -e ./stopmove ] \n");
+        print($out "    then\n");
+        print($out "    echo \"stopmove found.  Exiting.\"\n");
+        print($out "    exit\n");
+        print($out "else\n");
+        print($out "    echo \"stopmove not found---continuing.\"\n");
+        print($out "fi\n");
+        printf ($out "echo \"Moving %s - move %d - size %d\"\n", 
                 $v, $cnt,  $sk);
-        print out "date\n";
+        print($out "date\n");
         my $cmd = "/ncsd/batch/mvto $v "
             . "$opt_outserver $this_part "
             . $replicaList;
-        print out "echo \"Executing: $cmd\"\n";
-        print out "$cmd\n";
+        print($out "echo \"Executing: $cmd\"\n");
+        print($out "$cmd\n");
         
     }
 }
 
 if ($outOpened) {
-    print out "# \n";
-    print out "# $cnt moves\n";
-    close out;
+    print($out "# \n");
+    print($out "# $cnt moves\n");
+    close $out;
     $outOpened = 0;
 }
 
@@ -255,7 +264,7 @@ if ($delete_list) {
     unlink $delete_list;
 }
 
-print "$cnt moves\n";
+print("$cnt moves\n");
 
 if ($opt_update) {
     chmod 0755, $outFile;
@@ -266,6 +275,13 @@ if ($opt_update) {
 exit;
 
 __END__
+
+##############################################################################
+# Documentation
+##############################################################################
+
+=for stopwords
+afs inserver listvol mkmove mvto rw vos
 
 =head1 NAME
 
@@ -279,10 +295,10 @@ afs-mkmove-rw
 
 =head1 DESCRIPTION
 
-The script takes in a volume list or in input server and parition list
+The script takes in a volume list or in input server and partition list
 and generates a shell script that uses mvto to move AFS volumes to the
 output server and partition list.  Only RW volumes are considered for
-this script.  Volumes are moved to the output paritions in the order
+this script.  Volumes are moved to the output partitions in the order
 entered.
 
 =head1 OPTIONS AND ARGUMENTS
@@ -298,12 +314,12 @@ Name of the destination AFS server.
 A comma separated list of partitions to move volumes to on the output
 server.  Volumes are move to the first partition in the list until
 that partition is --full percent full, and then volume movement
-proceeds to the next parition until the list is exhausted.
+proceeds to the next partition until the list is exhausted.
 
 =item --full=percent
 
-The percent of available space consumed on a parition that is
-considered full.  Once a parition is full no volumes will be moved to
+The percent of available space consumed on a partition that is
+considered full.  Once a partition is full no volumes will be moved to
 it.
 
 This parameter is optional.  The default it 75.
@@ -312,8 +328,8 @@ This parameter is optional.  The default it 75.
 
 A text file containing the output of a vos listvol command.  This
 parameter is optional, but if not specified then --inserver must be
-present.  The parition list is expected to be the output from "vos
-listvol" and can be the concatentation of volume lists from multiple
+present.  The partition list is expected to be the output from "vos
+listvol" and can be the concatenation of volume lists from multiple
 servers.
 
 =item --inserver=host
@@ -322,7 +338,7 @@ The name of the host to move RW volumes from to the output server.
 
 =item --inpart=part-lists
 
-A comma separated list of parititions to move.
+A comma separated list of partitions to move.
 
 =item --update
 
@@ -337,6 +353,18 @@ Turns on debugging displays.
 Print complete documentation.
 
 =back
+
+=head1 COPYRIGHT
+
+Copyright 2008-2015 The Board of Trustees of the Leland Stanford
+Junior University.
+
+Copyright 2018, 2024 Bill MacAllister <bill@ca-zephyr.org>.
+
+=head1 LICENSE
+
+This program is free software; you may redistribute it and/or modify it
+under the same terms as Perl itself.
 
 =head1 AUTHOR
 

--- a/frak
+++ b/frak
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-our $VERSION = '2.5 (2024-07-17)';
+our $VERSION = '2.6 (2024-07-25)';
 #
 # frak -- Show changes between two AFS trees.
 #
@@ -35,11 +35,11 @@ use warnings;
 use vars qw($CHANGEDIR $CROSSMOUNT $DEBUG $LOGFILE $MUNGE $NODIFF $QUIET
   $ROOTRO $ROOTRW);
 
-use Cwd qw(cwd);
-use File::Find qw(find);
-use File::stat qw(lstat);
+use Cwd          qw(cwd);
+use File::Find   qw(find);
+use File::stat   qw(lstat);
 use Getopt::Long qw(GetOptions);
-use POSIX qw(strftime);
+use POSIX        qw(strftime);
 use Stat::lsMode qw(format_mode);
 
 ##############################################################################
@@ -54,7 +54,7 @@ our $DIFF = 'diff';
 
 # The full path to fs and vos.  vos may be in an sbin directory, which may
 # not be on the user's path by default, so check there first.
-our $FS = 'fs';
+our $FS  = 'fs';
 our $VOS = grep { -x $_ } qw(/usr/local/sbin/vos /usr/sbin/vos);
 $VOS ||= 'vos';
 
@@ -681,11 +681,11 @@ sub analyze_forward {
 
     # Do the analysis, or rather call all the individual functions that do the
     # analysis.
-    if (!$roinfo{stat}) { compare_new(\%rwinfo) }
-    elsif ($rwinfo{islink}) { compare_link(\%rwinfo, \%roinfo) }
+    if    (!$roinfo{stat})          { compare_new(\%rwinfo) }
+    elsif ($rwinfo{islink})         { compare_link(\%rwinfo, \%roinfo) }
     elsif (defined $rwinfo{volume}) { compare_mount(\%rwinfo, \%roinfo) }
-    elsif ($rwinfo{isdir}) { compare_dir(\%rwinfo, \%roinfo) }
-    else                   { compare_file(\%rwinfo, \%roinfo) }
+    elsif ($rwinfo{isdir})          { compare_dir(\%rwinfo, \%roinfo) }
+    else                            { compare_file(\%rwinfo, \%roinfo) }
 }
 
 # Compare in the reverse direction (read-only to read/write).  The only thing

--- a/fsr
+++ b/fsr
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-our $VERSION = '2.5 (2024-07-17)';
+our $VERSION = '2.6 (2024-07-25)';
 #
 # fsr -- Recursively apply AFS fs commands.
 #
@@ -26,7 +26,7 @@ use warnings;
 
 use vars qw($CROSSMOUNTS $NOMOUNTS $VERBOSE);
 
-use File::Find qw(find);
+use File::Find   qw(find);
 use Getopt::Long qw(GetOptions);
 
 # We fork fs lsmount inside a grep (in File::Find) and expect to be able to do

--- a/lsmounts
+++ b/lsmounts
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-our $VERSION = '2.5 (2024-07-17)';
+our $VERSION = '2.6 (2024-07-25)';
 #
 # lsmounts -- List mountpoints found in a directory.
 #
@@ -27,8 +27,8 @@ use 5.006;
 use strict;
 use warnings;
 
-use Cwd qw(cwd);
-use File::Find qw(find);
+use Cwd          qw(cwd);
+use File::Find   qw(find);
 use Getopt::Long qw(GetOptions);
 
 my $count;

--- a/mvto
+++ b/mvto
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-our $VERSION = '2.5 (2024-07-17)';
+our $VERSION = '2.6 (2024-07-25)';
 #
 # mvto -- Move an AFS volume from anywhere, intelligently.
 #
@@ -36,19 +36,15 @@ use warnings;
 use vars qw($JUSTPRINT);
 use subs qw(system);
 
-use Date::Parse qw(str2time);
+use Date::Parse  qw(str2time);
 use Getopt::Long qw(GetOptions);
 
 # This will be set to -localauth if that flag should be added to vos
 # commands.
 our $LOCALAUTH = '';
 
-# Test to find out whether the server is OpenAFS or YFS
+# If set the script assumes Auristor AFS
 our $YFS_SERVER;
-my $vos_version = `vos --version`;
-if ($vos_version =~ /^auristor/xms) {
-    $YFS_SERVER = 1;
-}
 
 ##############################################################################
 # Site configuration
@@ -434,7 +430,7 @@ sub move_rw {
     my @to = ($toserver, $topart);
     my ($fromserver, $frompart) = ($$volinfo{rwserver}, $$volinfo{rwpart});
     my @from = ($fromserver, $frompart);
-    my %ro = %{ $$volinfo{ro} };
+    my %ro   = %{ $$volinfo{ro} };
 
     # If the volume is replicated and the read/write is already on the right
     # server, we won't actually move it.  Just make sure there's also a
@@ -581,7 +577,7 @@ sub move_volume {
 sub move_single {
     my ($volume, $force, @location) = @_;
     my @source = findpartition(splice(@location, 0, 2));
-    my @dest = findpartition(@location);
+    my @dest   = findpartition(@location);
 
     # Get and display information about the volume.
     my %volinfo = volinfo($volume);
@@ -686,6 +682,12 @@ if ($help) {
 }
 if ($LOCALAUTH) {
     $LOCALAUTH = '-localauth';
+}
+
+# Set the AFS style
+my $vos_version = `vos --version`;
+if ($vos_version =~ /^auristor/xms) {
+    $YFS_SERVER = 1;
 }
 
 # Volume name is always the first argument unless -l or -L was given, and the

--- a/partinfo
+++ b/partinfo
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-our $VERSION = '2.5 (2024-07-17)';
+our $VERSION = '2.6 (2024-07-25)';
 #
 # partinfo -- Show summary of space on AFS server partitions.
 #
@@ -39,12 +39,8 @@ my $opt_human;
 # Site configuration
 ##############################################################################
 
-# Test to find out whether the server is OpenAFS or YFS
+# If set assumes Auristor syntax
 our $YFS_SERVER;
-my $vos_version = `vos --version`;
-if ($vos_version =~ /^auristor/xms) {
-    $YFS_SERVER = 1;
-}
 
 # The default thresholds.  The first gives the threshold before the partition
 # is considered reasonably well-utilized, and defaults to 60%.  The second
@@ -124,7 +120,7 @@ sub show {
     my $usable = int($free - ((100 - $PARTINFO_FULL) / 100) * $total);
     my $pfree  = 100 * $used / $total;
     my $cstart = $color ? choose_color($pfree) : '';
-    my $cend   = $color ? color('reset') : '';
+    my $cend   = $color ? color('reset')       : '';
     my $fmt    = "%17s: %10d %10d %10d %s%7.2f%%%s %10d\n";
     if ($opt_human) {
         $total  = human_bytes($total * 1024);
@@ -173,6 +169,12 @@ if (@ARGV != 1) {
 my $server = shift;
 if (($server =~ /^\d+$/)) {
     $server = 'afssvr' . $server;
+}
+
+# Check for AFS flavor
+my $vos_version = `vos --version`;
+if ($vos_version =~ /^auristor/xms) {
+    $YFS_SERVER = 1;
 }
 
 # Process threshold argument if provided.

--- a/t/strict.t
+++ b/t/strict.t
@@ -29,4 +29,4 @@ Test::Strict->import;
 # Test everything in the distribution directory.  We also want to check use
 # warnings.
 $Test::Strict::TEST_WARNINGS = 1;
-all_perl_files_ok();
+all_perl_files_ok('blib/script');

--- a/volcreate
+++ b/volcreate
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-our $VERSION = '2.5 (2024-07-17)';
+our $VERSION = '2.6 (2024-07-25)';
 #
 # volcreate -- Create a volume, mount and set acl and quota
 #
@@ -66,7 +66,7 @@ our $LOADMTPT = '';
 
 # The full path to fs and vos.  vos may be in an sbin directory, which may
 # not be on the user's path by default, so check there first.
-our $FS = 'fs';
+our $FS  = 'fs';
 our $VOS = grep { -x $_ } qw(/usr/local/sbin/vos /usr/sbin/vos);
 $VOS ||= 'vos';
 
@@ -600,7 +600,7 @@ __END__
 ##############################################################################
 
 =for stopwords
-ACL AFS Crellin acl afs-admin-tools afssvr3 afssvr14 fs -hnqv loadmtpt
+ACL afs Crellin acl afs-admin-tools afssvr3 afssvr14 fs -hnq loadmtpt
 afs-mountpoints partinfo pubsw rra volcreate vos pubsw.byacc19
 
 =head1 NAME
@@ -662,7 +662,7 @@ I<volume> is the name of the volume to create.  I<quota> is the
 volume's quota.  The quota value defaults to megabytes (B<not> in
 kilobytes) if not units are specified.  Valid quota units are k, m, g,
 and t which are kilobytes, megabytes, gigabytes, and terabytes
-respecitively.  I<mount> is the full path to the intended mount
+respectively.  I<mount> is the full path to the intended mount
 location of the volume (this must begin with $VOLCREATE_MOUNT_PREFIX
 so that the mount point database remains consistent).  I<acl> is any
 normal ACL arguments to C<fs setacl>.  The quota, mount point, and

--- a/volcreate-logs
+++ b/volcreate-logs
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-our $VERSION = '2.5 (2024-07-17)';
+our $VERSION = '2.6 (2024-07-25)';
 #
 # volcreate-logs -- Create and grant quota to log volumes in AFS.
 #
@@ -26,7 +26,7 @@ use vars qw($JUSTPRINT $MAIL $MAILOPEN);
 use subs qw(system);
 
 use Getopt::Long qw(GetOptions);
-use POSIX qw(strftime);
+use POSIX        qw(strftime);
 
 # AFS::Utils is loaded to get the setpag function if a ticket cache is
 # specified on the command line.
@@ -54,7 +54,7 @@ our $VOLCREATE = 'volcreate';
 
 # The full path to fs and vos.  vos may be in an sbin directory, which may
 # not be on the user's path by default, so check there first.
-our $FS = 'fs';
+our $FS  = 'fs';
 our $VOS = grep { -x $_ } qw(/usr/local/sbin/vos /usr/sbin/vos);
 $VOS ||= 'vos';
 
@@ -154,10 +154,10 @@ sub kbytes {
 
 sub display_kbytes {
     my ($quota_kbytes) = @_;
-    my @sizes = ('T', 'G', 'M');
-    my $quota = "${quota_kbytes}K";
-    my $i     = $quota_kbytes;
-    my $u     = 'K';
+    my @sizes          = ('T', 'G', 'M');
+    my $quota          = "${quota_kbytes}K";
+    my $i              = $quota_kbytes;
+    my $u              = 'K';
     while ($i > 1024) {
         if (@sizes) {
             $i     = $i / 1024;
@@ -244,7 +244,7 @@ sub find_volume_month {
     my ($volume, $path);
     if (-d "$base/$year/$month") {
         $volume = lsmount("$base/$year/$month");
-        $path = "$base/$year/$month" if defined $volume;
+        $path   = "$base/$year/$month" if defined $volume;
     }
     return ($volume, $path);
 }
@@ -275,7 +275,7 @@ sub find_volume_year {
 sub create_volume {
     my ($volume, $mountpoint, $quota, $quiet) = @_;
     my $quota_kbytes = kbytes($quota);
-    my $max = kbytes($LOGS_MAX_QUOTA);
+    my $max          = kbytes($LOGS_MAX_QUOTA);
     if ($quota_kbytes > $max) {
         my $s = display_kbytes($quota_kbytes);
         my $m = display_kbytes($max);
@@ -304,7 +304,7 @@ sub create_volume {
     }
     if (system($VOLCREATE, @command) != 0) {
         warn "$VOLCREATE -t logs $volume $quota_kbytes $mountpoint exited ",
-	  "with status ", ($? >> 8), "\n";
+          "with status ", ($? >> 8), "\n";
         warn "$volume not fully created, please check\n";
     } else {
         my $s = display_kbytes($quota_kbytes);
@@ -335,7 +335,7 @@ sub create_log_volume {
     my ($year, $month, $config, $quiet) = @_;
     my ($path, $volume);
     if ($$config{type} eq 'monthly') {
-        $path = sprintf("$$config{path}/%04d/%02d", $year, $month);
+        $path   = sprintf("$$config{path}/%04d/%02d", $year, $month);
         $volume = sprintf("%s.%04d%02d", $$config{name}, $year, $month);
         if (!-d "$$config{path}/$year") {
             if ($JUSTPRINT) {
@@ -347,7 +347,7 @@ sub create_log_volume {
             }
         }
     } elsif ($$config{type} eq 'yearly') {
-        $path = sprintf("$$config{path}/%04d", $year);
+        $path   = sprintf("$$config{path}/%04d", $year);
         $volume = sprintf("%s.%04d", $$config{name}, $year);
     }
     if (!-d $path) {
@@ -383,7 +383,7 @@ sub parse_log {
             }
         }
         my ($key, $value) = split(/:\s+/, $_, 2);
-        $key =~ s/^\s+//;
+        $key   =~ s/^\s+//;
         $value =~ s/\s+$//;
         if (!$value) {
             warn "Parse error in log group on line $.\n";
@@ -463,7 +463,7 @@ if ($ticket) {
         $ticket = $LOGS_TICKETS . '/' . $ticket;
     }
     $ENV{KRB5CCNAME} = $ticket;
-    AFS::Utils::setpag() or die "$0: unable to setpag: $!";
+    AFS::Utils::setpag()      or die "$0: unable to setpag: $!";
     CORE::system($AKLOG) == 0 or die "$0: unable to obtain tokens";
 }
 

--- a/volnuke
+++ b/volnuke
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-our $VERSION = '2.5 (2024-07-17)';
+our $VERSION = '2.6 (2024-07-25)';
 #
 # volnuke -- Delete a volume, tracking down what servers it's on.
 #
@@ -33,24 +33,20 @@ use 5.006;
 use strict;
 use warnings;
 
-use Date::Parse qw(str2time);
+use Date::Parse  qw(str2time);
 use Getopt::Long qw(GetOptions);
-use POSIX qw(strftime);
+use POSIX        qw(strftime);
 
 ##############################################################################
 # Site configuration
 ##############################################################################
 
-# Test to find out whether the server is OpenAFS or YFS
+# If set assumes Auristor syntax
 our $YFS_SERVER;
-my $vos_version = `vos --version`;
-if ($vos_version =~ /^auristor/xms) {
-    $YFS_SERVER = 1;
-}
 
 # The full path to fs and vos.  vos may be in an sbin directory, which may
 # not be on the user's path by default, so check there first.
-our $FS = 'fs';
+our $FS  = 'fs';
 our $VOS = grep { -x $_ } qw(/usr/local/sbin/vos /usr/sbin/vos);
 $VOS ||= 'vos';
 
@@ -272,6 +268,13 @@ if ($help) {
 if (@ARGV != 1) {
     usage();
 }
+
+# Check for AFS flavor
+my $vos_version = `vos --version`;
+if ($vos_version =~ /^auristor/xms) {
+    $YFS_SERVER = 1;
+}
+
 my $volume;
 if ($mountpoint) {
     $mountpoint = shift;


### PR DESCRIPTION
The addition of the afs-mkmove-* scripts exposed the fact that using normal perl installation methodology was causing tests to be run files that were not perl scripts.  This update restricts tests to perl scripts.

This change includes some code cleanup dictated by perltidy and minor POD updates. 